### PR TITLE
Allow build parallelism.

### DIFF
--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -17,6 +17,8 @@ ARG tor_key
 
 ARG keyserver
 
+ARG jobs
+
 RUN \
   apt-get update && \
   apt-get install -y build-essential curl autotools-dev automake gnupg2
@@ -27,7 +29,7 @@ RUN \
   tar -zxvf zlib-$zlib_version.tar.gz && \
   cd zlib-$zlib_version && \
   ./configure --prefix=$PWD/install && \
-  make && make check && make install
+  make ${jobs:+-j${jobs}} && make ${jobs:+-j$jobs} check && make install
   
 RUN \  
   curl -fsSL "https://github.com/libevent/libevent/releases/download/release-$libevent_version/libevent-$libevent_version.tar.gz" -o libevent-$libevent_version.tar.gz && \
@@ -41,7 +43,8 @@ RUN \
               --disable-shared \
               --enable-static \
               --with-pic && \
-  make && make check && make install
+  ulimit -n 65536 && \
+  make ${jobs:+-j$jobs} && make ${jobs:+-j$jobs} check && make install
 
 RUN \
   curl -fsSL "https://www.openssl.org/source/openssl-$openssl_version.tar.gz" -o openssl-$openssl_version.tar.gz && \
@@ -49,7 +52,7 @@ RUN \
   tar -xvzf openssl-$openssl_version.tar.gz && \
   cd openssl-$openssl_version && \
   ./config --prefix=$PWD/install no-shared no-dso && \
-  make && make test && make install
+  make ${jobs:+-j$jobs} && make test && make install
 
 RUN \  
   curl -fsSL "https://www.torproject.org/dist/tor-$tor_version.tar.gz" -o tor-$tor_version.tar.gz && \
@@ -65,6 +68,6 @@ RUN \
               --with-openssl-dir=$PWD/../openssl-$openssl_version/install \
               --with-zlib-dir=$PWD/../zlib-$zlib_version/install \
               --disable-asciidoc && \
-  make && make check && make install
+  make ${jobs:+-j$jobs} && make ${jobs:+-j$jobs} check && make install
 
 ENTRYPOINT while :; do read; done

--- a/Dockerfile-mingw
+++ b/Dockerfile-mingw
@@ -33,8 +33,8 @@ RUN \
   echo "$zlib_hash  zlib-$zlib_version.tar.gz" | shasum -a 256 -c - && \
   tar -zxvf zlib-$zlib_version.tar.gz && \
   cd zlib-$zlib_version && \
-  make ${jobs+-j$jobs} -f win32/Makefile.gcc PREFIX=i686-w64-mingw32- && \
-  make ${jobs+-j$jobs} -f win32/Makefile.gcc PREFIX=i686-w64-mingw32- \
+  make ${jobs:+-j$jobs} -f win32/Makefile.gcc PREFIX=i686-w64-mingw32- && \
+  make ${jobs:+-j$jobs} -f win32/Makefile.gcc PREFIX=i686-w64-mingw32- \
     BINARY_PATH="$PWD/install/bin" \
     INCLUDE_PATH="$PWD/install/include" \
     LIBRARY_PATH="$PWD/install/lib" \
@@ -53,7 +53,7 @@ RUN \
               --enable-static \
               --with-pic \
               --host=i686-w64-mingw32 && \
-  make ${jobs+-j$jobs} && make ${jobs+-j$jobs} install
+  make ${jobs:+-j$jobs} && make ${jobs:+-j$jobs} install
 
 RUN \
   curl -fsSL "https://www.openssl.org/source/openssl-$openssl_version.tar.gz" -o openssl-$openssl_version.tar.gz && \
@@ -62,7 +62,7 @@ RUN \
   cd openssl-$openssl_version && \
   ./Configure --prefix=$PWD/install --cross-compile-prefix=i686-w64-mingw32- \
     mingw no-shared no-dso && \
-  make ${jobs+-j$jobs} && make ${jobs+-j$jobs} install_sw
+  make ${jobs:+-j$jobs} && make ${jobs:+-j$jobs} install_sw
 
 RUN \
   curl -fsSL "https://www.torproject.org/dist/tor-$tor_version.tar.gz" -o tor-$tor_version.tar.gz && \
@@ -80,6 +80,6 @@ RUN \
               --disable-asciidoc \
               --host=i686-w64-mingw32 \
               LIBS=-lcrypt32 && \
-  make ${jobs+-j$jobs} && make ${jobs+-j$jobs} install
+  make ${jobs:+-j$jobs} && make ${jobs:+-j$jobs} install
 
 ENTRYPOINT while :; do read; done

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -2,6 +2,6 @@
 set -eu
 
 docker rm -fv tor-brave || true
-docker build -t tor-brave -f Dockerfile-linux --build-arg tor_version=$TOR_VERSION --build-arg zlib_version=$ZLIB_VERSION --build-arg libevent_version=$LIBEVENT_VERSION --build-arg openssl_version=$OPENSSL_VERSION --build-arg zlib_hash=$ZLIB_HASH --build-arg libevent_hash=$LIBEVENT_HASH --build-arg libevent_key=$LIBEVENT_KEY --build-arg openssl_hash=$OPENSSL_HASH --build-arg tor_hash=$TOR_HASH --build-arg tor_key=$TOR_KEY --build-arg keyserver="$KEYSERVER" .
+docker build -t tor-brave -f Dockerfile-linux --build-arg tor_version=$TOR_VERSION --build-arg zlib_version=$ZLIB_VERSION --build-arg libevent_version=$LIBEVENT_VERSION --build-arg openssl_version=$OPENSSL_VERSION --build-arg zlib_hash=$ZLIB_HASH --build-arg libevent_hash=$LIBEVENT_HASH --build-arg libevent_key=$LIBEVENT_KEY --build-arg openssl_hash=$OPENSSL_HASH --build-arg tor_hash=$TOR_HASH --build-arg tor_key=$TOR_KEY --build-arg keyserver="$KEYSERVER" ${1+"$@"} .
 docker run --name tor-brave -d tor-brave
 docker cp tor-brave:/tor-$TOR_VERSION/src/or/tor tor-$TOR_VERSION-linux-brave-$BRAVE_TOR_VERSION


### PR DESCRIPTION
Works for Linux and mingw32 builds.  Generalizing to Darwin left as an exercise for the reader.

Usage: ./build_linux.sh --build-arg jobs=8
Usage: ./build_mingw32.sh --build-arg jobs=8

Should make turnaround time a _little_ faster!