### PR TITLE
Fix 44: Move XZ temporarily to use static library only

### DIFF
--- a/build_darwin.sh
+++ b/build_darwin.sh
@@ -66,6 +66,7 @@ curl -fsSL "https://www.torproject.org/dist/tor-$TOR_VERSION.tar.gz.asc" -o tor-
 gpg --import gpg-keys/tor.gpg
 gpg tor-$TOR_VERSION.tar.gz.asc
 echo "$TOR_HASH  tor-$TOR_VERSION.tar.gz" | shasum -a 256 -c - && \
+mv $XZ_DIR $NEW_XZ_DIR
 tar -xvzf tor-$TOR_VERSION.tar.gz
 cd tor-$TOR_VERSION && \
 ./configure --prefix=$PWD/root \
@@ -79,6 +80,7 @@ cd tor-$TOR_VERSION && \
             ac_cv_func_getentropy=no \
             ac_cv_func_clock_gettime=no && \
 make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+mv $NEW_XZ_DIR $XZ_DIR
 cd ..
 
 cp tor-$TOR_VERSION/root/bin/tor tor-$TOR_VERSION-darwin-brave-$BRAVE_TOR_VERSION

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export XZ_DIR='/usr/local/opt/xz/lib'
+export NEW_XZ_DIR='/usr/local/opt/xz/brave-lib'
+
 export BRAVE_TOR_VERSION="1"
 export TOR_VERSION="0.3.5.8"
 


### PR DESCRIPTION
Fix #44 

macOS prefers linking to dylib if it exists, temporarily moving `xz` libs to a new location so that xz is statically linked to the binary: https://dropline.net/2015/10/static-linking-on-mac-os-x/ 