### PR TITLE
fix macos crash

### DIFF
--- a/build_darwin_x86_64.sh
+++ b/build_darwin_x86_64.sh
@@ -79,6 +79,7 @@ cd "x86_64/tor-$TOR_VERSION"
             --with-zlib-dir="$PWD/../zlib-$ZLIB_VERSION/root" \
             --disable-asciidoc \
             --disable-lzma \
+            --disable-zstd \
             ac_cv_func_getentropy=no \
             ac_cv_func_clock_gettime=no
 make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install


### PR DESCRIPTION
it seems zstd needs to be disabled on x86 since it's disabled on arm macos already; otherwise x86 tor binary will crash with zstd not found errors (https://bravesoftware.slack.com/archives/C85NV6NSG/p1644290020694139)