### PR TITLE
Bump BRAVE_TOR_VERSION

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,7 @@
 export MACOSX_DEPLOYMENT_TARGET=10.10
 
 # Reset version number to zero everytime TOR_VERSION changes.
-export BRAVE_TOR_VERSION="0"
+export BRAVE_TOR_VERSION="1"
 
 export TOR_VERSION="0.4.7.13"
 


### PR DESCRIPTION
Our tor binary on Windows is signed with an Authenticode certificate that expires in August. This PR bumps `BRAVE_TOR_VERSION` to let us release a new version whose only change is that it is signed with a new certificate.

Resolves https://github.com/brave/brave-browser/issues/31439.