### PR TITLE
OpenSSL3 fix

### DIFF
--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -74,7 +74,7 @@ RUN \
 
 RUN \
   cd "openssl-$openssl_version" && \
-  ./config --prefix="$PWD/root" \
+  ./config --prefix="$PWD/root" --libdir=lib \
     no-dso \
     no-shared \
     no-ssl-trace \

--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -75,7 +75,10 @@ RUN \
 RUN \
   cd "openssl-$openssl_version" && \
   ./config --prefix="$PWD/root" \
-    no-shared no-dso && \
+    no-dso \
+    no-shared \
+    no-ssl-trace \
+    no-ui-console && \
   make ${jobs:+-j${jobs}} && \
   make test && \
   make install

--- a/Dockerfile-linux-arm64
+++ b/Dockerfile-linux-arm64
@@ -78,7 +78,10 @@ RUN \
   ./Configure --prefix="$PWD/root" \
     --cross-compile-prefix=aarch64-linux-gnu- \
     linux-aarch64 \
-    no-shared no-dso && \
+    no-dso \
+    no-shared \
+    no-ssl-trace \
+    no-ui-console && \
   make ${jobs:+-j${jobs}} && \
   make install_sw
 

--- a/Dockerfile-mingw
+++ b/Dockerfile-mingw
@@ -80,7 +80,10 @@ RUN \
   ./Configure --prefix="$PWD/root" \
     --cross-compile-prefix=i686-w64-mingw32- \
     mingw \
-    no-shared no-dso && \
+    no-dso \
+    no-shared \
+    no-ssl-trace \
+    no-ui-console && \
   make ${jobs:+-j${jobs}} && \
   make install_sw
 

--- a/build_darwin_arm64.sh
+++ b/build_darwin_arm64.sh
@@ -26,7 +26,13 @@ cd ../../
 
 tar -xvzf "openssl-$OPENSSL_VERSION.tar.gz" -C arm64
 cd "arm64/openssl-$OPENSSL_VERSION"
-./Configure --prefix="$PWD/root" darwin64-arm64-cc no-shared no-dso
+./Configure --prefix="$PWD/root" \
+            darwin64-arm64-cc \
+            no-dso \
+            no-shared \
+            no-ssl-trace \
+            no-ui-console
+
 make ${jobs:+-j${jobs}} && make install
 cd ../../
 

--- a/build_darwin_x86_64.sh
+++ b/build_darwin_x86_64.sh
@@ -26,7 +26,12 @@ cd ../../
 
 tar -xvzf "openssl-$OPENSSL_VERSION.tar.gz" -C x86_64
 cd "x86_64/openssl-$OPENSSL_VERSION"
-./Configure --prefix="$PWD/root" darwin64-x86_64-cc no-shared no-dso
+./Configure --prefix="$PWD/root" \
+            darwin64-x86_64-cc \
+            no-dso \
+            no-shared \
+            no-ssl-trace \
+            no-ui-console
 make ${jobs:+-j${jobs}} && make test && make install
 cd ../../
 


### PR DESCRIPTION
This small fix is required for https://github.com/brave/tor_build_scripts/issues/133 due to the fact that [OpenSSL switched from `lib/` to `lib64/` on some platforms](https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/issues/40854#note_2910046).