### PR TITLE
Fix Mac x86 64 builds

### DIFF
--- a/build_darwin_arm64.sh
+++ b/build_darwin_arm64.sh
@@ -78,7 +78,7 @@ patch -p0 < ../../patch/libevent/regress.c.patch
   --host=$BUILD_HOST \
   --disable-clock-gettime \
   --with-pic
-make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+make ${jobs:+-j${jobs}} && make install
 cd ../../
 
 tar -xvzf "tor-$TOR_VERSION.tar.gz" -C $BUILD_CPU

--- a/build_darwin_x86_64.sh
+++ b/build_darwin_x86_64.sh
@@ -78,7 +78,7 @@ patch -p0 < ../../patch/libevent/regress.c.patch
   --host=$BUILD_HOST \
   --disable-clock-gettime \
   --with-pic
-make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+make ${jobs:+-j${jobs}} && make install
 cd ../../
 
 tar -xvzf "tor-$TOR_VERSION.tar.gz" -C $BUILD_CPU


### PR DESCRIPTION
This PR harmonizes the way that both arm64 and x86_64 binaries are built and explicitly sets the compilation CPU and HOST so that they can be built on either architecture.

The individual commits are probably easier to review due to the indentation fixes.