### PR TITLE
Disable zlib tests on x86_64-apple-darwin

### DIFF
--- a/build_darwin_arm64.sh
+++ b/build_darwin_arm64.sh
@@ -24,7 +24,7 @@ rm -rf $BUILD_CPU && mkdir $BUILD_CPU
 tar -xvzf "zlib-$ZLIB_VERSION.tar.gz" -C $BUILD_CPU
 cd "$BUILD_CPU/zlib-$ZLIB_VERSION"
 CFLAGS="-target $BUILD_CPU-apple-macos11" LDFLAGS="-target $BUILD_CPU-apple-macos11" ./configure --prefix="$PWD/root"
-make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+make ${jobs:+-j${jobs}} && make install
 cd ../../
 
 tar -xvzf "openssl-$OPENSSL_VERSION.tar.gz" -C $BUILD_CPU


### PR DESCRIPTION
These are broken when cross-compiling for `x86_64` on `arm64`:
```
12:03:26  gcc -dynamiclib -install_name /Users/jenkins/jenkins/workspace/brave-tor-client-build-macos/x86_64/zlib-1.3.1/root/lib/libz.1.dylib -compatibility_version 1 -current_version 1.3.1 -target x86_64-apple-macos11 -fPIC -DHAVE_HIDDEN -o libz.1.3.1.dylib adler32.lo crc32.lo deflate.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo zutil.lo compress.lo uncompr.lo gzclose.lo gzlib.lo gzread.lo gzwrite.lo  -lc -target x86_64-apple-macos11

2:03:26 
 /bin/sh: ./minigzip: Bad CPU type in executable
12:03:26 
 /bin/sh: ./minigzip: Bad CPU type in executable
12:03:26  		*** zlib test FAILED ***
12:03:26 
 make: *** [teststatic] Error 1
12:03:26  make: *** Waiting for unfinished jobs....
12:03:26  /bin/sh: ./minigzipsh: Bad CPU type in executable
12:03:26  /bin/sh: ./minigzipsh: Bad CPU type in executable
12:03:26  		*** zlib shared test FAILED ***
12:03:26  make: *** [testshared] Error 1
```