### PR TITLE
Fix mac builds

### DIFF
--- a/build_darwin_arm64.sh
+++ b/build_darwin_arm64.sh
@@ -24,7 +24,7 @@ rm -rf $BUILD_CPU && mkdir $BUILD_CPU
 tar -xvzf "zlib-$ZLIB_VERSION.tar.gz" -C $BUILD_CPU
 cd "$BUILD_CPU/zlib-$ZLIB_VERSION"
 CFLAGS="-target $BUILD_CPU-apple-macos11" LDFLAGS="-target $BUILD_CPU-apple-macos11" ./configure --prefix="$PWD/root"
-make ${jobs:+-j${jobs}} && make install
+make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
 cd ../../
 
 tar -xvzf "openssl-$OPENSSL_VERSION.tar.gz" -C $BUILD_CPU

--- a/build_darwin_x86_64.sh
+++ b/build_darwin_x86_64.sh
@@ -24,7 +24,7 @@ rm -rf $BUILD_CPU && mkdir $BUILD_CPU
 tar -xvzf "zlib-$ZLIB_VERSION.tar.gz" -C $BUILD_CPU
 cd "$BUILD_CPU/zlib-$ZLIB_VERSION"
 CFLAGS="-target $BUILD_CPU-apple-macos11" LDFLAGS="-target $BUILD_CPU-apple-macos11" ./configure --prefix="$PWD/root"
-make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+make ${jobs:+-j${jobs}} && make install
 cd ../../
 
 tar -xvzf "openssl-$OPENSSL_VERSION.tar.gz" -C $BUILD_CPU

--- a/build_darwin_x86_64.sh
+++ b/build_darwin_x86_64.sh
@@ -106,5 +106,5 @@ patch -p0 < ../../patch/tor/test_slow.c.patch
   --disable-tool-name-check \
   ac_cv_func_getentropy=no \
   ac_cv_func_clock_gettime=no
-make ${jobs:+-j${jobs}} && make ${jobs:+-j${jobs}} check && make install
+make ${jobs:+-j${jobs}} && make install
 cd ../../


### PR DESCRIPTION
Fix for https://github.com/brave/tor_build_scripts/pull/164 which disabled the zlib tests for the wrong architecture, and disable the tor tests entirely on Mac.