### PR TITLE
Tor 0.4.9.8-0 update

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -6,15 +6,15 @@ export MACOSX_DEPLOYMENT_TARGET=10.15
 # Reset version number to zero everytime TOR_VERSION changes.
 export BRAVE_TOR_VERSION="0"
 
-export TOR_VERSION="0.4.9.6"
+export TOR_VERSION="0.4.9.8"
 
 export ZLIB_VERSION="1.3.2"
 export LIBEVENT_VERSION="2.1.12-stable"
-export OPENSSL_VERSION="3.6.1"
+export OPENSSL_VERSION="4.0.0"
 
 export ZLIB_HASH="bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16"
 export LIBEVENT_HASH=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
-export OPENSSL_HASH="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
-export TOR_HASH="a89aba97052e9963a654b40df2d46be07e8a6b6e24e5437917fd81acd90a7017"
+export OPENSSL_HASH="c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac"
+export TOR_HASH="ac1f394e2dd2ab0877d27d928fd0d9e86662fe3ca6afdffb9fd9b6f0f96d05de"
 
 export DOCKER="$(command -v docker || command -v podman)"


### PR DESCRIPTION
https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.8/ChangeLog
https://github.com/openssl/openssl/releases/tag/openssl-4.0.0

