### PR TITLE
Deps dashboard monitoring

### DIFF
--- a/DEPS_MONITORING.md
+++ b/DEPS_MONITORING.md
@@ -1,22 +1,60 @@
-Since we can't use Dependabot to monitor these C packages/libraries automatically,
-we rely on the folllowing sources:
+# Monitoring dependency versions
+
+The pinned versions and hashes live in [`env.sh`](env.sh): `TOR_VERSION`,
+`ZLIB_VERSION`, `LIBEVENT_VERSION`, `OPENSSL_VERSION` and their matching
+`*_HASH` values.
+
+## Primary: Renovate Dependency Dashboard
+
+Renovate watches the `*_VERSION` lines in `env.sh` (see the `customManagers` in
+[`renovate.json`](renovate.json)) and lists any available upstream releases on
+the repo's **Dependency Dashboard** issue. It is configured with
+`dependencyDashboardApproval`, so it never opens PRs on its own — the dashboard
+is purely a notification surface.
+
+When the dashboard shows a newer version, run the `brave-tor-client-release`
+Jenkins job (see the release steps in [`README.md`](README.md)) with the new
+version and hash; that job opens the bump PR.
+
+## Fallback: upstream sources
+
+If Renovate is unavailable or a release is missed, these are the upstream
+sources:
 
 - Libevent: [GitHub repo tags](https://github.com/libevent/libevent/tags.atom)
 - OpenSSL: [upstream changelog](https://www.openssl.org/news/cl111.txt)
-- Tor: [packager mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-packagers) and [annoucements forum topic](https://forum.torproject.org/c/news/tor-release-announcement/28)
+- Tor: [packager mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-packagers) and [announcements forum topic](https://forum.torproject.org/c/news/tor-release-announcement/28)
 - Zlib: [upstream changeLog](https://zlib.net/ChangeLog.txt)
 
-Libevent is monitored using an RSS reader.
+## Where the hashes come from
 
-OpenSSL and Zlib are monitored using a local git repo which keeps a copy of the
-latest version of the changelog and a daily cronjob to update it:
+The `*_HASH` in `env.sh` is the SHA256 of the canonical source tarball. The
+build (`Dockerfile-linux` and friends) GPG-verifies each tarball against the
+keys in `gpg-keys/` and then checks it against `*_HASH`, so the trust anchor is
+the GPG signature; the hash is a pin you compute after verifying.
 
+- **Tor** publishes a signed hash file directly — read it from
+  `https://dist.torproject.org/tor-<version>.tar.gz.sha256sum`
+  (verify with the adjacent `.sha256sum.asc`).
+- **zlib / libevent / openssl** ship a detached GPG signature (`.asc`) but no
+  hash file used by the build; download the canonical tarball, verify the
+  signature, then run `shasum -a 256`.
+
+Canonical URLs (same ones the build downloads from):
+
+```sh
+# tor       -> hash is published, just read it
+curl -fsSL https://dist.torproject.org/tor-$TOR_VERSION.tar.gz.sha256sum
+
+# zlib
+curl -fsSL https://zlib.net/zlib-$ZLIB_VERSION.tar.gz | shasum -a 256
+
+# libevent
+curl -fsSL https://github.com/libevent/libevent/releases/download/release-$LIBEVENT_VERSION/libevent-$LIBEVENT_VERSION.tar.gz | shasum -a 256
+
+# openssl
+curl -fsSL https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz | shasum -a 256
 ```
-#!/bin/bash
 
-pushd ~/openssl-changelog > /dev/null
-wget --quiet -O cl111.txt https://www.openssl.org/news/cl111.txt || exit 1
-git diff
-git commit -a -m "Updated changelog" > /dev/null
-popd > /dev/null
-```
+Always GPG-verify the tarball (as the Dockerfiles do) before trusting a hash
+you computed yourself.

--- a/DEPS_MONITORING.md
+++ b/DEPS_MONITORING.md
@@ -24,7 +24,7 @@ sources:
 - Libevent: [GitHub repo tags](https://github.com/libevent/libevent/tags.atom)
 - OpenSSL: [upstream changelog](https://openssl-library.org/news/changelog/) and [security advisories](https://openssl-library.org/news/vulnerabilities/)
 - Tor: [packager mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-packagers) and [announcements forum topic](https://forum.torproject.org/c/news/tor-release-announcement/28)
-- Zlib: [upstream changeLog](https://zlib.net/ChangeLog.txt)
+- Zlib: [upstream ChangeLog](https://zlib.net/ChangeLog.txt)
 
 ## Where the hashes come from
 
@@ -36,7 +36,7 @@ the GPG signature; the hash is a pin you compute after verifying.
 - **Tor** publishes a signed hash file directly — read it from
   `https://dist.torproject.org/tor-<version>.tar.gz.sha256sum`
   (verify with the adjacent `.sha256sum.asc`).
-- **zlib / libevent / openssl** ship a detached GPG signature (`.asc`) but no
+- **zlib / libevent / OpenSSL** ship a detached GPG signature (`.asc`) but no
   hash file used by the build; download the canonical tarball, verify the
   signature, then run `shasum -a 256`.
 

--- a/DEPS_MONITORING.md
+++ b/DEPS_MONITORING.md
@@ -22,7 +22,7 @@ If Renovate is unavailable or a release is missed, these are the upstream
 sources:
 
 - Libevent: [GitHub repo tags](https://github.com/libevent/libevent/tags.atom)
-- OpenSSL: [upstream changelog](https://www.openssl.org/news/cl111.txt)
+- OpenSSL: [upstream changelog](https://openssl-library.org/news/changelog/) and [security advisories](https://openssl-library.org/news/vulnerabilities/)
 - Tor: [packager mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-packagers) and [announcements forum topic](https://forum.torproject.org/c/news/tor-release-announcement/28)
 - Zlib: [upstream changeLog](https://zlib.net/ChangeLog.txt)
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,54 @@
   "extends": [
     "local>brave/renovate-config"
   ],
-  "addLabels": ["CI/skip", "dependencies", "renovate"]
+  "addLabels": ["CI/skip", "dependencies", "renovate"],
+  "dependencyDashboard": true,
+  "dependencyDashboardApproval": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^env\\.sh$"],
+      "matchStrings": ["TOR_VERSION=\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "tor",
+      "packageNameTemplate": "tpo/core/tor",
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.torproject.org",
+      "extractVersionTemplate": "^tor-(?<version>.+)$",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^env\\.sh$"],
+      "matchStrings": ["ZLIB_VERSION=\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "zlib",
+      "packageNameTemplate": "madler/zlib",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^env\\.sh$"],
+      "matchStrings": ["LIBEVENT_VERSION=\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "libevent",
+      "packageNameTemplate": "libevent/libevent",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^release-(?<version>.+)$",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^env\\.sh$"],
+      "matchStrings": ["OPENSSL_VERSION=\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "openssl",
+      "packageNameTemplate": "openssl/openssl",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^openssl-(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["tor"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+\\.\\d+$/"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>brave/renovate-config"
+    "local>brave/renovate-config",
+    "local>brave/renovate-config:enable-vulnerability-alerts"
   ],
   "addLabels": ["CI/skip", "dependencies", "renovate"],
   "dependencyDashboard": true,
@@ -51,6 +52,11 @@
     {
       "matchDepNames": ["tor"],
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "description": "Surface new releases on the dashboard immediately instead of waiting out the 7-day minimumReleaseAge from the base config; safe because this repo is dashboard-only and every entry is triaged by hand.",
+      "matchDepNames": ["tor", "zlib", "libevent", "openssl"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
Supposedly this does the following:

Add customManagers to renovate.json so Renovate watches the *_VERSION lines in env.sh for tor/zlib/libevent/openssl and lists available upstream releases on the Dependency Dashboard. Configured with dependencyDashboardApproval so it never opens PRs on its own — the brave-tor-client-release Jenkins job remains responsible for that.

Rewrite DEPS_MONITORING.md to lead with the dashboard as the primary signal, keep the upstream RSS/changelog/mailing-list sources as fallback, and document where each tarball's SHA256 hash comes from.